### PR TITLE
Add python3 shebang, make sure save_location is an absolute path

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import click
 import os
 import re

--- a/scraper.py
+++ b/scraper.py
@@ -268,7 +268,7 @@ def main():
     print(str(sys.argv))
 
     if len(sys.argv) > 3:
-        save_location = sys.argv[1]
+        save_location = os.path.abspath(sys.argv[1])
         base_url = sys.argv[2]
         start_url = sys.argv[3]
 


### PR DESCRIPTION
Hi,

today I have started using your software to download art. I have made 2 small changes for ease of use:

Adding a shebang line makes it possible to run the script using `$ ./scraper.py` (without python command). The second change makes sure that the given `save_location` parameter is an absolute path (relative paths can give undesired, deeply nested folder-structure).

I think these might be useful to others as well :)

Cheers.